### PR TITLE
refactor : change variable name

### DIFF
--- a/models/mlp_svm.py
+++ b/models/mlp_svm.py
@@ -57,12 +57,8 @@ class MLP:
                 # [BATCH_SIZE, NUM_FEATURES]
                 x_input = tf.placeholder(dtype=tf.float32, shape=[None, self.num_features], name='x_input')
 
-                # [BATCH_SIZE]
-                y_input = tf.placeholder(dtype=tf.uint8, shape=[None], name='y_input')
-
                 # [BATCH_SIZE, NUM_CLASSES]
-                y_onehot = tf.one_hot(indices=y_input, depth=self.num_classes, on_value=1.0, off_value=-1.0,
-                                      name='y_onehot')
+                y_input = tf.placeholder(dtype=tf.uint8, shape=[None, self.num_classes], name='y_input')
 
             learning_rate = tf.placeholder(dtype=tf.float32, name='learning_rate')
 
@@ -93,7 +89,7 @@ class MLP:
             tf.summary.histogram('pre-activations', output_layer)
 
             with tf.name_scope('loss'):
-                loss = svm_loss(labels=y_onehot, logits=output_layer, num_classes=self.num_classes,
+                loss = svm_loss(labels=y_input, logits=output_layer, num_classes=self.num_classes,
                                 penalty_parameter=self.penalty_parameter, weight=last_hidden_layer['weights'])
             tf.summary.scalar('loss', loss)
 
@@ -101,8 +97,9 @@ class MLP:
 
             with tf.name_scope('accuracy'):
                 predicted_class = tf.sign(output_layer)
+                predicted_class = tf.identity(predicted_class, name='predicted_class')
                 with tf.name_scope('correct_prediction'):
-                    correct_prediction = tf.equal(tf.argmax(predicted_class, 1), tf.argmax(y_onehot, 1))
+                    correct_prediction = tf.equal(tf.argmax(predicted_class, 1), tf.argmax(y_input, 1))
                 with tf.name_scope('accuracy'):
                     accuracy = tf.reduce_mean(tf.cast(correct_prediction, 'float'))
             tf.summary.scalar('accuracy', accuracy)
@@ -111,7 +108,6 @@ class MLP:
 
             self.x_input = x_input
             self.y_input = y_input
-            self.y_onehot = y_onehot
             self.learning_rate = learning_rate
             self.loss = loss
             self.optimizer_op = optimizer_op
@@ -123,39 +119,52 @@ class MLP:
         __graph__()
         sys.stdout.write('</log>\n')
 
-    def train(self, num_epochs, log_path, train_data, train_size, test_data, test_size, result_path):
-        """Trains the MLP model
+    def train(self, checkpoint_path, num_epochs, log_path, train_data, train_size, test_data, test_size, result_path):
+        """Trains the initialized MLP-SVM model.
 
-        Parameter
-        ---------
-        num_epochs : int
-          The number of passes over the entire dataset.
-        log_path : str
-          The path where to save the TensorBoard logs.
-        train_data : numpy.ndarray
-          The NumPy array to be used as training dataset.
-        train_size : int
-          The size of the `train_data`.
-        test_data : numpy.ndarray
-          The NumPy array to be used as testing dataset.
-        test_size : int
-          The size of the `test_data`.
+        :param checkpoint_path: The path where to save the trained model.
+        :param num_epochs: The number of passes over the entire dataset.
+        :param log_path: The path where to save the TensorBoard logs.
+        :param train_data: The NumPy array to be used as training dataset.
+        :param train_size: The size of the `train_data`.
+        :param test_data: The NumPy array to be used as testing dataset.
+        :param test_size: The size of the `test_data`.
+        :param result_path: The path where to save the actual and predicted labels, for later analysis
+        :return:
         """
 
-        # initialize the variables
-        init_op = tf.group(tf.global_variables_initializer(), tf.local_variables_initializer())
+        if not os.path.exists(path=checkpoint_path):
+            os.mkdir(path=checkpoint_path)
+
+        if not os.path.exists(path=log_path):
+            os.mkdir(path=log_path)
 
         timestamp = str(time.asctime())
+
+        saver = tf.train.Saver(max_to_keep=2)
+        # initialize the variables
+        init_op = tf.group(tf.global_variables_initializer(), tf.local_variables_initializer())
 
         train_writer = tf.summary.FileWriter(log_path + timestamp + '-training', graph=tf.get_default_graph())
         test_writer = tf.summary.FileWriter(log_path + timestamp + '-test', graph=tf.get_default_graph())
 
         with tf.Session() as sess:
+
             sess.run(init_op)
+
+            checkpoint = tf.train.get_checkpoint_state(checkpoint_dir=checkpoint_path)
+
+            if checkpoint and checkpoint.model_checkpoint_path:
+                saver = tf.train.import_meta_graph(checkpoint.model_checkpoint_path + '.meta')
+                saver.restore(sess, tf.train.latest_checkpoint(checkpoint_dir=checkpoint_path))
+                print('Loaded {}'.format(tf.train.latest_checkpoint(checkpoint_dir=checkpoint_path)))
 
             try:
                 for step in range(num_epochs * train_size // self.batch_size):
+
                     offset = (step * self.batch_size) % train_size
+
+                    # train by batch
                     train_data_batch = train_data[0][offset:(offset + self.batch_size)]
                     train_label_batch = train_data[1][offset:(offset + self.batch_size)]
 
@@ -166,9 +175,18 @@ class MLP:
                                                            feed_dict=feed_dict)
 
                     if step % 100 == 0 and step > 0:
+
+                        # get the training accuracy at current time step
                         train_accuracy = sess.run(self.accuracy, feed_dict=feed_dict)
+
+                        # display the training accuracy
                         print('step [{}] train -- loss : {}, accuracy : {}'.format(step, step_loss, train_accuracy))
+
+                        # add TensorBoard summary
                         train_writer.add_summary(train_summary, global_step=step)
+
+                        # save the model at this time step
+                        saver.save(sess=sess, save_path=os.path.join(checkpoint_path, self.name), global_step=step)
 
             except KeyboardInterrupt:
                 print('KeyboardInterrupt at step {}'.format(step))
@@ -177,22 +195,29 @@ class MLP:
                 print('EOF -- Training done at step {}'.format(step))
 
                 for step in range(num_epochs * test_size // self.batch_size):
+
                     offset = (step * self.batch_size) % test_size
+
+                    # test by batch
                     test_data_batch = test_data[0][offset:(offset + self.batch_size)]
                     test_label_batch = test_data[1][offset:(offset + self.batch_size)]
 
                     feed_dict = {self.x_input: test_data_batch, self.y_input: test_label_batch}
 
                     test_summary, test_accuracy, test_loss, predictions, actual = \
-                        sess.run([self.merged, self.accuracy, self.loss, self.predicted_class, self.y_onehot],
+                        sess.run([self.merged, self.accuracy, self.loss, self.predicted_class, self.y_input],
                                  feed_dict=feed_dict)
 
                     if step % 100 == 0 and step > 0:
+
+                        # display testing loss and accuracy
                         print('step [{}] test -- loss : {}, accuracy : {}'.format(step, test_loss, test_accuracy))
+
+                        # add TensorBoard summary
                         test_writer.add_summary(test_summary, step)
 
                     save_labels(predictions=predictions, actual=actual, result_path=result_path, phase='testing',
-                                step=step)
+                                model=self.name, step=step)
 
                 print('EOF -- Testing done at step {}'.format(step))
 


### PR DESCRIPTION
* Remove the `y_onehot` graph variable, use the `y_input` graph variable instead. This is because the data to be fed is already one-hot encoded outside of the inference graph
* Change the graph ops that use `y_onehot` to use the `y_input`
* Add some comment documentation
* Add `checkpoint_path`, to save the trained model